### PR TITLE
fixed macos code

### DIFF
--- a/src/main/java/net/samuelcampos/usbdrivedectector/detectors/OSXStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedectector/detectors/OSXStorageDeviceDetector.java
@@ -53,6 +53,7 @@ public class OSXStorageDeviceDetector extends AbstractStorageDeviceDetector {
     
     private static final int MACOS_SIERRA = 12;
     private static final int MACOS_ELCAPITAN = 11;
+    private static final int MACOSX_MOUNTAINLION = 8;
     
     private int macosVersion;
     
@@ -79,7 +80,7 @@ public class OSXStorageDeviceDetector extends AbstractStorageDeviceDetector {
     public List<USBStorageDevice> getStorageDevicesDevices() {
         final ArrayList<USBStorageDevice> listDevices = new ArrayList<>();
         
-        if(macosVersion >= MACOS_ELCAPITAN){
+        if(macosVersion >= MACOSX_MOUNTAINLION){
         	try (CommandExecutor commandExecutor = new CommandExecutor(CMD_DF)) {
         		
         		commandExecutor.processOutput((String outputLine) -> {

--- a/src/main/java/net/samuelcampos/usbdrivedectector/detectors/OSXStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedectector/detectors/OSXStorageDeviceDetector.java
@@ -20,6 +20,7 @@ import net.samuelcampos.usbdrivedectector.process.CommandExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,29 +39,131 @@ public class OSXStorageDeviceDetector extends AbstractStorageDeviceDetector {
      * system_profiler SPUSBDataType | grep "BSD Name:\|Mount Point:"
      */
     private static final String CMD_SYSTEM_PROFILER_USB = "system_profiler SPUSBDataType";
-    private static final Pattern macOSXPattern = Pattern.compile("^.*Mount Point: (.+)$");
+    private static final Pattern macOSXPattern_MOUNT = Pattern.compile("^.*Mount Point: (.+)$");
+    
+    private static final String CMD_DF = "df -l";
+    private static final String CMD_DISKUTIL = "diskutil info ";
+    
+    private static final String DISK_PREFIX = "/dev/disk";
+   
+    private static final String INFO_MOUNTPOINT = "Mount Point";
+    private static final String INFO_PROTOCOL = "Protocol";
+    private static final String INFO_USB = "USB";
+    private static final String INFO_NAME = "Volume Name";
+    
+    private static final int MACOS_SIERRA = 12;
+    
+    private int macosVersion;
+    
+    
 
     protected OSXStorageDeviceDetector() {
         super();
+        
+        String version = System.getProperty("os.version");
+        String[] versionParts = version.split("\\.");
+        if(versionParts.length > 1){
+        	try{
+        		macosVersion = Integer.parseInt(versionParts[1]);
+        	}
+        	catch(NumberFormatException nfe){
+        		logger.error(nfe.getMessage(), nfe);
+        	}
+        }
+    
     }
 
+    
     @Override
     public List<USBStorageDevice> getStorageDevicesDevices() {
         final ArrayList<USBStorageDevice> listDevices = new ArrayList<>();
+        
+        if(macosVersion >= MACOS_SIERRA){
+        	try (CommandExecutor commandExecutor = new CommandExecutor(CMD_DF)) {
+        		
+        		commandExecutor.processOutput((String outputLine) -> {
+                    String[] parts = outputLine.split("\\s");
+                    String device = parts[0];
 
-        try (CommandExecutor commandExecutor = new CommandExecutor(CMD_SYSTEM_PROFILER_USB)) {
-            commandExecutor.processOutput(outputLine -> {
-                final Matcher matcher = macOSXPattern.matcher(outputLine);
+                    if(device.startsWith(DISK_PREFIX)){
+                    	DiskInfo disk = new DiskInfo(device);
+                    	readDiskInfo(disk);
+                    	
+                    	if(disk.isUSB){
+                    		listDevices.add(new USBStorageDevice(new File(disk.mountPoint), disk.name));
+                    	}
+                    }
+        			
+        		});
 
-                if (matcher.matches()) {
-                    listDevices.add(getUSBDevice(matcher.group(1)));
-                }
-            });
+        	} catch (IOException e) {
+        		logger.error(e.getMessage(), e);
+        	}
+        }
+        else{
+        	try (CommandExecutor commandExecutor = new CommandExecutor(CMD_SYSTEM_PROFILER_USB)) {
+        		commandExecutor.processOutput(outputLine -> {
+        			final Matcher matcher = macOSXPattern_MOUNT.matcher(outputLine);
 
-        } catch (IOException e) {
-            logger.error(e.getMessage(), e);
+        			if (matcher.matches()) {
+        				listDevices.add(getUSBDevice(matcher.group(1)));
+        			}
+        		});
+
+        	} catch (IOException e) {
+        		logger.error(e.getMessage(), e);
+        	}
         }
 
         return listDevices;
     }
+
+
+	private void readDiskInfo(DiskInfo disk) {
+		// TODO Auto-generated method stub
+		
+		String command = CMD_DISKUTIL +  disk.device;
+
+		try (CommandExecutor commandExecutor = new CommandExecutor(command)) {
+			
+    		commandExecutor.processOutput(outputLine -> {
+    			
+    			String[] parts = outputLine.split(":");
+    			
+    			if(parts.length > 1){
+    				if(INFO_MOUNTPOINT.equals(parts[0].trim())){
+    					disk.mountPoint = parts[1].trim();
+    				}
+    				else if(INFO_PROTOCOL.equals(parts[0].trim())){
+    					disk.isUSB = INFO_USB.equals(parts[1].trim());
+    				}
+    				else if(INFO_NAME.equals(parts[0].trim())){
+    					disk.name = parts[1].trim();
+    				}
+    			}
+    			
+    			
+    		});
+
+    	} catch (IOException e) {
+    		logger.error(e.getMessage(), e);
+    	}
+		
+	}
+	
+	private class DiskInfo{
+		
+		public DiskInfo(String device){
+			this.device = device;
+			mountPoint = "";
+			name = "";
+			isUSB = false;
+		}
+		
+		String device;
+		String mountPoint;
+		String name;
+		boolean isUSB;
+		
+	}
 }

--- a/src/main/java/net/samuelcampos/usbdrivedectector/detectors/OSXStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedectector/detectors/OSXStorageDeviceDetector.java
@@ -52,6 +52,7 @@ public class OSXStorageDeviceDetector extends AbstractStorageDeviceDetector {
     private static final String INFO_NAME = "Volume Name";
     
     private static final int MACOS_SIERRA = 12;
+    private static final int MACOS_ELCAPITAN = 11;
     
     private int macosVersion;
     
@@ -78,7 +79,7 @@ public class OSXStorageDeviceDetector extends AbstractStorageDeviceDetector {
     public List<USBStorageDevice> getStorageDevicesDevices() {
         final ArrayList<USBStorageDevice> listDevices = new ArrayList<>();
         
-        if(macosVersion >= MACOS_SIERRA){
+        if(macosVersion >= MACOS_ELCAPITAN){
         	try (CommandExecutor commandExecutor = new CommandExecutor(CMD_DF)) {
         		
         		commandExecutor.processOutput((String outputLine) -> {


### PR DESCRIPTION
The system_profiler commands weren't working -- the SPUSBDataType output doesn't include the Mount Point anymore so I used df and diskutil instead.  I tested it on Mac OSX 10.8, 10.11, and 10.12, and I'm comfortable assuming it will work on 10.9 and 10.10 too. 

After this commit, I took my fork off in a direction that you may not want to go (like fixing the misspelled package name and removing guava dependency). I also need to get it working in Java 1.6, so I'll probably have to make some bigger changes.  

I plan to fix a problem with the Linux detector there too, though. I want it to preserve the volume name -- which isn't always the mount point.  I can mount a volume called "MyUSBKey" at mount point "/media/usb", but the current code then thinks the volume name is "usb".  I'll try to pull that fix over onto this "backward compatible" branch that I plan to keep in sync with your master.

Thanks,

Matt