### PR TITLE
Bug fix: Inverted false check

### DIFF
--- a/src/main/java/net/samuelcampos/usbdrivedetector/USBDeviceDetectorManager.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/USBDeviceDetectorManager.java
@@ -80,7 +80,7 @@ public class USBDeviceDetectorManager {
      *                        storage devices on the system.
      */
     public synchronized void setPollingInterval(final long pollingInterval) {
-        if (pollingInterval >= 0) {
+        if (pollingInterval <= 0) {
             throw new IllegalArgumentException("'pollingInterval' must be greater than 0");
         }
 


### PR DESCRIPTION
In the original repository, in the file "USBDeviceDetectorManager.java" and in the method setPollingInterval there is a check, whether the method's parameter is greater than, or equal to, 0, whereas it should be less than, or equal to, zero.