### PR TITLE
Limit "invalid root file" error propagation on win

### DIFF
--- a/src/main/java/net/samuelcampos/usbdrivedetector/detectors/AbstractStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/detectors/AbstractStorageDeviceDetector.java
@@ -84,6 +84,12 @@ public abstract class AbstractStorageDeviceDetector {
     static USBStorageDevice getUSBDevice(final String rootPath, final String deviceName) {
         final File root = new File(rootPath);
 
+        if (!root.isDirectory()) {
+            // Sometimes commands returns an invalid directory
+            logger.trace("Invalid root found: {}", root);
+            return null;
+        }
+
         logger.trace("Device found: {}", root.getPath());
 
         try {

--- a/src/main/java/net/samuelcampos/usbdrivedetector/detectors/WindowsStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/detectors/WindowsStorageDeviceDetector.java
@@ -51,7 +51,10 @@ public class WindowsStorageDeviceDetector extends AbstractStorageDeviceDetector 
             commandExecutor.processOutput(outputLine -> {
                 if (!outputLine.isEmpty() && !"DeviceID".equals(outputLine)) {
                     final String rootPath = outputLine + File.separatorChar;
-                    listDevices.add(getUSBDevice(rootPath, getDeviceName(rootPath)));
+                    USBStorageDevice device = getUSBDevice(rootPath, getDeviceName(rootPath));
+                    if (device != null) {
+                        listDevices.add(device);
+                    }
                 }
             });
 


### PR DESCRIPTION
Sometimes the wmic command returns invalid roots.
This commit ignores these roots (instead of crashing) as they are "false allarms" and can safely be ignored.