### PR TITLE
- Fix SimpleTest unmount (check if collections is empty to avoid

### DIFF
--- a/src/main/java/net/samuelcampos/usbdrivedetector/detectors/WindowsStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/detectors/WindowsStorageDeviceDetector.java
@@ -15,16 +15,16 @@
  */
 package net.samuelcampos.usbdrivedetector.detectors;
 
-import lombok.extern.slf4j.Slf4j;
-import net.samuelcampos.usbdrivedetector.USBStorageDevice;
-import net.samuelcampos.usbdrivedetector.process.CommandExecutor;
-import net.samuelcampos.usbdrivedetector.utils.OSUtils;
-
-import javax.swing.filechooser.FileSystemView;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import javax.swing.filechooser.FileSystemView;
+
+import lombok.extern.slf4j.Slf4j;
+import net.samuelcampos.usbdrivedetector.USBStorageDevice;
+import net.samuelcampos.usbdrivedetector.process.CommandExecutor;
 
 /**
  *
@@ -33,25 +33,13 @@ import java.util.List;
 @Slf4j
 public class WindowsStorageDeviceDetector extends AbstractStorageDeviceDetector {
 
-    private static final String WMIC_PATH_WIN8 = "wmic";
-    // Window 10 broke compatibility by removing the wbem dir from his PATH
-    private static final String WMIC_PATH_WIN10 = System.getenv("WINDIR") + "\\System32\\wbem\\wmic";
+    private static final String WMIC_PATH = System.getenv("WINDIR") + "\\System32\\wbem\\wmic.exe";
 
     /**
      * wmic logicaldisk where drivetype=2 get description,deviceid,volumename
      */
-    private static final String CMD_WMI_ARGS = "logicaldisk where drivetype=2 get deviceid, VolumeSerialNumber";
-    private static final String CMD_WMI_USB;
-
-    static {
-        String wmicPath;
-        if (Float.parseFloat(OSUtils.getOsVersion()) >= 6.2) {
-            wmicPath = WMIC_PATH_WIN8;
-        } else {
-            wmicPath = WMIC_PATH_WIN10;
-        }
-        CMD_WMI_USB = wmicPath + " " + CMD_WMI_ARGS;
-    }
+    private static final String CMD_WMI_ARGS = "logicaldisk where drivetype=2 get DeviceID,VolumeSerialNumber";
+    private static final String CMD_WMI_USB = WMIC_PATH + " " + CMD_WMI_ARGS;
 
     protected WindowsStorageDeviceDetector() {
         super();

--- a/src/test/java/net/samuelcampos/usbdrivedetector/SimpleTest.java
+++ b/src/test/java/net/samuelcampos/usbdrivedetector/SimpleTest.java
@@ -26,7 +26,9 @@ public class SimpleTest implements IUSBDriveListener{
             e.printStackTrace();
         }
 
-        driveDetector.unmountStorageDevice(driveDetector.getRemovableDevices().get(0));
+        if (!driveDetector.getRemovableDevices().isEmpty()) {
+            driveDetector.unmountStorageDevice(driveDetector.getRemovableDevices().get(0));        	
+        }
 
         try {
             Thread.sleep(20000);


### PR DESCRIPTION
- Fix SimpleTest unmount (check if collection is empty to avoid outofbounds exception);

- Found some issues on Windows wmic command when not using its full path. From now on Win10, Win8 and Win7 uses same wmic command path.