### PR TITLE
Update Windows device detector code to derive the volume label via th…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 .idea/
 *.iml
 *.iws
+/.project
+/.settings
+/.classpath

--- a/src/main/java/net/samuelcampos/usbdrivedetector/USBStorageDevice.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/USBStorageDevice.java
@@ -90,6 +90,11 @@ public class USBStorageDevice {
      * @return the name of the root of this device as it would be displayed in a system file browser.
      */
     public String getSystemDisplayName() {
-	    return FileSystemView.getFileSystemView().getSystemDisplayName(rootDirectory);
+    	String driveLetter = rootDirectory.getPath();
+    	if (driveLetter.endsWith("\\"))
+    	{
+    		driveLetter = driveLetter.substring(0, driveLetter.length()-1);
+    	}
+	    return deviceName + " (" + driveLetter + ")";
     }
 }

--- a/src/main/java/net/samuelcampos/usbdrivedetector/detectors/WindowsStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/detectors/WindowsStorageDeviceDetector.java
@@ -79,21 +79,30 @@ public class WindowsStorageDeviceDetector extends AbstractStorageDeviceDetector 
     }
 
     private String parseVolumeName(String[] parts) {
-    	String volumeLabel = "";
+    	StringBuilder volumeLabel = new StringBuilder();
     	// in our array of strings, the device ID will be at first position
     	// the volume serial number will be in the final position, and all 
     	// other elements in the array will either be empty string (multiple 
-    	// occurrences), or the volume label (zero or one occurrence)
+    	// occurrences), or parts of the volume label (if there is a volume 
+    	// label at all)
     	for (int i = 1; i < parts.length-1; i++) {
 			if (!parts[i].isEmpty())
 			{
-				volumeLabel = parts[i];
+				if (volumeLabel.length() > 0)
+				{
+					// if we had a previous word in our volume label, then the label 
+					// is made up of multiple white-space separate words => let's 
+					// add back in the required whitespace in the volume label
+					// between the word parts
+					volumeLabel.append(" ");
+				}
+				volumeLabel.append(parts[i]);
 			}
 		}
     	
     	// note: if there is NO label on the volume then none will be found in 
     	// the array and empty string will be returned
-		return volumeLabel;
+		return volumeLabel.toString();
 	}
 
 	private String getDeviceName(final String rootPath) {

--- a/src/main/java/net/samuelcampos/usbdrivedetector/detectors/WindowsStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/detectors/WindowsStorageDeviceDetector.java
@@ -38,7 +38,7 @@ public class WindowsStorageDeviceDetector extends AbstractStorageDeviceDetector 
     /**
      * wmic logicaldisk where drivetype=2 get description,deviceid,volumename
      */
-    private static final String CMD_WMI_ARGS = "logicaldisk where drivetype=2 get DeviceID,VolumeSerialNumber";
+    private static final String CMD_WMI_ARGS = "logicaldisk where drivetype=2 get DeviceID,VolumeSerialNumber,VolumeName";
     private static final String CMD_WMI_USB = WMIC_PATH + " " + CMD_WMI_ARGS;
 
     protected WindowsStorageDeviceDetector() {
@@ -57,8 +57,16 @@ public class WindowsStorageDeviceDetector extends AbstractStorageDeviceDetector 
                 if(parts.length > 1 && !parts[0].isEmpty() && !parts[0].equals("DeviceID") && !parts[0].equals(parts[parts.length - 1])) {
                 	final String rootPath = parts[0] + File.separatorChar;
                     final String uuid = parts[parts.length - 1];
-
-                    getUSBDevice(rootPath, getDeviceName(rootPath), rootPath, uuid)
+                    String volumeName = parseVolumeName(parts);
+                    if (volumeName.isEmpty())
+                    {
+                    	// if the volume label via WMIC is blank, lets fall-back on 
+                    	// FileSystemView.getSystemDisplayName(File) to derive a user-friendly
+                    	// localised generic name (eg. 'USB Drive')
+                    	volumeName = getDeviceName(rootPath);
+                    }
+                    
+                    getUSBDevice(rootPath, volumeName, rootPath, uuid)
                             .ifPresent(listDevices::add);
                 }
             });
@@ -70,7 +78,25 @@ public class WindowsStorageDeviceDetector extends AbstractStorageDeviceDetector 
         return listDevices;
     }
 
-    private String getDeviceName(final String rootPath) {
+    private String parseVolumeName(String[] parts) {
+    	String volumeLabel = "";
+    	// in our array of strings, the device ID will be at first position
+    	// the volume serial number will be in the final position, and all 
+    	// other elements in the array will either be empty string (multiple 
+    	// occurrences), or the volume label (zero or one occurrence)
+    	for (int i = 1; i < parts.length-1; i++) {
+			if (!parts[i].isEmpty())
+			{
+				volumeLabel = parts[i];
+			}
+		}
+    	
+    	// note: if there is NO label on the volume then none will be found in 
+    	// the array and empty string will be returned
+		return volumeLabel;
+	}
+
+	private String getDeviceName(final String rootPath) {
         final File f = new File(rootPath);
         final FileSystemView v = FileSystemView.getFileSystemView();
         String name = v.getSystemDisplayName(f);

--- a/src/test/java/net/samuelcampos/usbdrivedetector/SimpleTest.java
+++ b/src/test/java/net/samuelcampos/usbdrivedetector/SimpleTest.java
@@ -21,7 +21,7 @@ public class SimpleTest implements IUSBDriveListener{
         driveDetector.addDriveListener(sTest);
 
         try {
-            Thread.sleep(360000);
+            Thread.sleep(20000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/src/test/java/net/samuelcampos/usbdrivedetector/SimpleTest.java
+++ b/src/test/java/net/samuelcampos/usbdrivedetector/SimpleTest.java
@@ -21,7 +21,7 @@ public class SimpleTest implements IUSBDriveListener{
         driveDetector.addDriveListener(sTest);
 
         try {
-            Thread.sleep(20000);
+            Thread.sleep(360000);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Update Windows device detector code to derive the volume label via the pre-existing WMIC command.  If the volume label is blank, then a fall-back on pre-existing usage of FileSystemView.getSystemDisplayName(File) is used to derive a user-friendly localised generic name (eg. 'USB Drive').

Note: this fixes an issue where the incorrect volume label was being shown in Windows 10 when changing SD cards (via unmount/mount) in an SD Card to USB reader.  The first volume label (first SD card inserted) was incorrectly shown as the display name of the USB storage device, for every subsequently inserted SD card.

The root cause appears to be a bug in FileSystemView.getSystemDisplayName(File), so this update is a workaround to derive volume label via WMIC.