### PR TITLE
Fix unmount for most recent macOS versions

### DIFF
--- a/src/main/java/net/samuelcampos/usbdrivedetector/unmounters/OSXStorageDeviceUnmounter.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/unmounters/OSXStorageDeviceUnmounter.java
@@ -21,8 +21,8 @@ public class OSXStorageDeviceUnmounter extends LinuxAndOSXStorageDeviceUnmounter
 
     @Override
     public void unmount(final USBStorageDevice usbStorageDevice) {
-	unmount("diskutil unmountDisk " + usbStorageDevice.getDevice());
-    	unmount("sudo diskutil unmountDisk " + usbStorageDevice.getDevice());
+        unmount("diskutil unmountDisk " + usbStorageDevice.getRootDirectory());
+        unmount("sudo diskutil unmountDisk " + usbStorageDevice.getRootDirectory());
     }
 
 }


### PR DESCRIPTION
On most recent macOS versions, the device is null (parsed output has probably changed), but the unmount command also works with root directory.