### PR TITLE
Could net.samuelcampos:usbdrivedetector:2.2.0-SNAPSHOT drop off redundant dependencies?

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,12 +57,28 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apiguardian</groupId>
+                    <artifactId>apiguardian-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
             <version>${junit.platform.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.platform</groupId>
+                    <artifactId>junit-platform-suite-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apiguardian</groupId>
+                    <artifactId>apiguardian-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Hi! I found the pom file of project **_net.samuelcampos:usbdrivedetector:2.2.0-SNAPSHOT_** introduced **_17_** dependencies. However, among them, **_2_** libraries (**_11%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.apiguardian:apiguardian-api:jar:1.1.2:test
org.junit.platform:junit-platform-suite-api:jar:1.8.2:test

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_org.junit.platform:junit-platform-suite-api:jar:1.8.2:test_** incorporates an incompatible license ECLIPSE PUBLIC LICENSE V2.0 (ECLIPSE PUBLIC LICENSE V2.0 cannot be used by the project with license The Apache Software License, Version 2.0). one of the redundant dependencies **_org.apiguardian:apiguardian-api:jar:1.1.2:test_** induced dependency conflict in the dependency graph. As such, I suggest a refactoring operation for **_net.samuelcampos:usbdrivedetector:2.2.0-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_net.samuelcampos:usbdrivedetector:2.2.0-SNAPSHOT_**’s maven tests.

Best regards