### PR TITLE
allow using a custom StorageDeviceDetector

### DIFF
--- a/src/main/java/net/samuelcampos/usbdrivedetector/USBDeviceDetectorManager.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/USBDeviceDetectorManager.java
@@ -75,6 +75,24 @@ public class USBDeviceDetectorManager implements Closeable {
     }
 
     /**
+     * Creates a new USBDeviceDetectorManager
+     * <p>
+     * The polling interval is used as the update frequency for any attached
+     * listeners. Instead of automatic OS detection a custom StorageDeviceDetector will be used for polling.
+     * </p>
+     * <p>
+     * Polling doesn't happen until at least one listener is attached.
+     * </p>
+     * @param pollingInterval the interval in milliseconds to poll for the USB
+     *                        storage devices on the system.
+     * @param customDeviceDetector the device detector to use
+     */
+    public USBDeviceDetectorManager(final long pollingInterval, AbstractStorageDeviceDetector customDeviceDetector) {
+        this(pollingInterval);
+        AbstractStorageDeviceDetector.setInstance(customDeviceDetector);
+    }
+
+    /**
      * Sets the polling interval
      *
      * @param pollingInterval the interval in milliseconds to poll for the USB

--- a/src/main/java/net/samuelcampos/usbdrivedetector/detectors/AbstractStorageDeviceDetector.java
+++ b/src/main/java/net/samuelcampos/usbdrivedetector/detectors/AbstractStorageDeviceDetector.java
@@ -46,6 +46,10 @@ public abstract class AbstractStorageDeviceDetector {
      */
     private static AbstractStorageDeviceDetector instance;
 
+    public static synchronized void setInstance(AbstractStorageDeviceDetector customInstance) {
+        instance = customInstance;
+    }
+
     public static synchronized AbstractStorageDeviceDetector getInstance() {
         if (instance == null) {
             final CommandExecutor commandExecutor = new CommandExecutor();


### PR DESCRIPTION
This pull request allows injecting of a custom StorageDeviceDetector. I use a OSHI based StorageDeviceDetector to detect USB attached Hard Drives (not signalized as removable by WMI) in addition to the standard detection routine on Windows 10. The following example could shows this usage but isn't included in the repository as it adds dependencies that might be problematic for some other projects (like JNA):

```java
import lombok.Getter;
import net.samuelcampos.usbdrivedetector.USBStorageDevice;
import net.samuelcampos.usbdrivedetector.detectors.WindowsStorageDeviceDetector;
import net.samuelcampos.usbdrivedetector.process.CommandExecutor;
import one.util.streamex.StreamEx;
import oshi.SystemInfo;
import oshi.hardware.HWPartition;
import oshi.hardware.UsbDevice;

import java.io.File;
import java.io.IOException;
import java.nio.file.Files;
import java.nio.file.Path;
import java.util.List;

public class WindowsJavaStorageDeviceDetector extends WindowsStorageDeviceDetector {

    public WindowsJavaStorageDeviceDetector(CommandExecutor commandExecutor) {
        super(System.getenv("WINDIR"), commandExecutor);
    }

    @Override
    public List<USBStorageDevice> getStorageDevices() {

        SystemInfo systemInfo = new SystemInfo();

        Path launchRoot = Path.of(System.getProperty("user.dir")).getRoot();
        List<UsbDevice> usbDevices = systemInfo.getHardware().getUsbDevices(false);

        return StreamEx.of(systemInfo.getHardware().getDiskStores())
                .flatMap(hw -> hw.getPartitions().stream().map(part -> new ExtendedPartitionInfo(part, hw.getSerial())))
                .filter(partition -> !partition.getMountPoint().equals(launchRoot.toString()))
                .filter(extendedPartitionInfo -> usbDevices.stream().anyMatch(usbDevice -> usbDevice.getSerialNumber().equals(extendedPartitionInfo.getHwSerial())))
                .map(partition -> {
                            try {
                                return new USBStorageDevice(new File(partition.getMountPoint()),
                                        Files.getFileStore(Path.of(partition.getMountPoint())).name(),
                                        partition.getMountPoint(), partition.getHwSerial());
                            } catch (IOException e) {
                                throw new RuntimeException(e);
                            }
                })
                .append(super.getStorageDevices())
                .distinct(USBStorageDevice::getRootDirectory)
                .toList();
    }

    private static class ExtendedPartitionInfo extends HWPartition {

        @Getter
        private final String hwSerial;
        /**
         * Creates a new HWPartition
         *
         * @param identification The unique partition id
         * @param name           Friendly name of the partition
         * @param type           Type or description of the partition
         * @param uuid           UUID
         * @param size           Size in bytes
         * @param major          Device ID (Major)
         * @param minor          Device ID (Minor)
         * @param mountPoint     Where the partition is mounted
         * @param driveHwSerial  Serial number of the containing hardware drive
         */
        public ExtendedPartitionInfo(String identification, String name, String type, String uuid, long size, int major,
                                     int minor, String mountPoint, String driveHwSerial) {
            super(identification, name, type, uuid, size, major, minor, mountPoint);
            hwSerial = driveHwSerial;
        }

        public ExtendedPartitionInfo(HWPartition partition, String driveHwSerial) {
            this(partition.getIdentification(), partition.getName(), partition.getName(), partition.getUuid(),
                    partition.getSize(), partition.getMajor(), partition.getMinor(), partition.getMountPoint(),
                    driveHwSerial);
        }

    }
}

```